### PR TITLE
check if storage acct's permissions align

### DIFF
--- a/contracts/mina/token-bridge/src/NoriStorageInterface.ts
+++ b/contracts/mina/token-bridge/src/NoriStorageInterface.ts
@@ -1,4 +1,4 @@
-import { Field, SmartContract, state, State, method } from 'o1js';
+import { Field, SmartContract, state, State, method, Provable, Types, assert, Permissions } from 'o1js';
 
 const underflowProtectionMessage = `lockedSoFar is less than mintedSoFar. 
 This would cause a negative mint amount (underflow), so minting is blocked. 
@@ -6,6 +6,8 @@ This situation arises when multiple Ethereum addresses deposit to the same nETH 
 which is outside the supported design and must be avoided.`;
 
 const zeroMintMessage = `No new amount to mint. The requested lockedSoFar equals mintedSoFar, minting zero tokens is not allowed.`;
+
+const PERMISSION_CHECK_ERROR_MESSAGE = `\`editState\` MUST be by proof and \`setPermissions\` MUST be by proof `;
 
 /** Stores  */
 export class NoriStorageInterface extends SmartContract {
@@ -15,10 +17,10 @@ export class NoriStorageInterface extends SmartContract {
   @method.returns(Field)
   async increaseMintedAmount(lockedSoFar: Field) {
     let mintedSoFar = this.mintedSoFar.getAndRequireEquals();
-    
+
     // Underflow protection (amountToMint cannot be negative)
     lockedSoFar.assertGreaterThanOrEqual(mintedSoFar, underflowProtectionMessage);
-    
+
     // Calculate amount to mint
     const amountToMint = lockedSoFar.sub(mintedSoFar);
 
@@ -35,4 +37,31 @@ export class NoriStorageInterface extends SmartContract {
     // this.self.body.mayUseToken = AccountUpdate.MayUseToken.InheritFromParent;
     // return this.self;
   }
+
+  /**
+ * check if permissions of Token Holder Account are properly set.
+ */
+  public checkPermissionsValidity() {
+    let permissions = this.self.update.permissions;
+
+    let { editState, setPermissions } = permissions.value;
+    let editStateIsProof = Provable.equal(
+      Types.AuthRequired,
+      editState,
+      Permissions.proof()
+    );
+    let setPermissionsIsProof = Provable.equal(
+      Types.AuthRequired,
+      setPermissions,
+      Permissions.proof()
+    );
+    let updateAllowed = editStateIsProof.and(setPermissionsIsProof);
+
+    assert(
+      updateAllowed,
+      PERMISSION_CHECK_ERROR_MESSAGE
+    );
+  }
+
+
 }

--- a/contracts/mina/token-bridge/src/NoriTokenController.ts
+++ b/contracts/mina/token-bridge/src/NoriTokenController.ts
@@ -170,6 +170,7 @@ export class NoriTokenController
         storage.userKeyHash
             .getAndRequireEquals()
             .assertEquals(Poseidon.hash(userAddress.toFields()));
+        storage.checkPermissionsValidity();
 
         // LHS e1 ->  s1 -> 1 RHS s1 + mpt + da .... 1 mint
 


### PR DESCRIPTION
As per [issue#20](https://github.com/Nori-zk/nori-bridge-sdk/issues/20), I added checks on if the storage account's permissions align with the ones specified within `NoriTokenController.setUpStorage(user: PublicKey, vk: VerificationKey)`