### PR TITLE
Build request 13/2/26 - 2nd attempt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
       contents: read
       pull-requests: write
     container:
-      image: docker.nori.it.com/stacksmith:2.0.0
+      image: docker.nori.it.com/stacksmith:2.0.5
       volumes:
         # SSH for git operations
         - /home/runner/.ssh:/root/.ssh:ro


### PR DESCRIPTION
The build pr https://github.com/Nori-zk/nori-bridge-sdk/pull/32 failed due to a mistake in a stacksmith workflow

- FIX: update stacksmith for build.yml to configure git before running any npm run publish command as it makes commits https://github.com/Nori-zk/nori-bridge-sdk/commit/ef570b0f725fbf152b3ae5b3a4fa5c6c07235442

This is an orphan build request of this PR: https://github.com/Nori-zk/nori-bridge-sdk/pull/32