### PR TITLE
FIX: Audit A2090 - Non-standard Merkle zero indexing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,94 @@
 # Changelog
 
+## 15/5/26 - Audit A2090: Non-standard Merkle zero indexing
+
+### Finding (verbatim)
+
+Finding a2090: `buildMerkleTree` uses the `zeros` array backwards
+
+Hi, we noticed an issue in nori-bridge-sdk\o1js-zk-utils\src\merkle-attestor\merkleTree.ts. When using zero hash while building the Merkle tree, the incorrect level/index is used.
+
+In buildMerkleTree (and also foldMerkleLeft and getMerklePathFromLeaves), zeros is set to be getMerkleZeros(depth) by the caller, which generates an array of Hashes that correspond to all-zero subtrees.
+
+```typescript
+/**
+ * Generate zero hashes array of length depth + 1
+ */
+export function getMerkleZeros(depth: number): Field[] {
+    const zeros: Field[] = [];
+
+    // Start with zeros[0] = Field(0)
+    zeros.push(Field(0));
+
+    for (let i = 1; i < depth + 1; i++) {
+        // Each next zero is hash of the previous zero with itself
+        zeros.push(Poseidon.hash([zeros[i - 1], zeros[i - 1]]));
+    }
+
+    return zeros;
+}
+```
+
+Notice that the array is ordered from smallest subtree (tree with a single 0 node, depth 0) to largest (tree of depth depth, i.e. depth+1 levels).
+
+However, in buildMerkleTree, when utilizing the zeros array, the following snippet is used:
+
+```typescript
+for (let level = depth; level > 0; level--) {
+    // Omitted...
+
+    for (let i = 0; i < parentWidth; i++) {
+        const leftIdx = 2 * i;
+
+        if (leftIdx >= nNonDummyNodes) {
+            // Both left and right dummy nodes, use zeros cache
+            parentLevel[i] = zeros[level];
+        } else {
+            // Omitted...
+        }
+    }
+    // Omitted...
+}
+```
+
+The zeros array is used backwards. e.g., when level=depth, the child level is the bottom layer of the tree, and the parent level is the layer above and hence should use zeros[1], hash that corresponds to a subtree of depth 1. Instead, the current code uses zeros[level], which is the hash for a subtree of depth depth.
+
+This leads to a completeness issue. The Mina bridge's off-chain witness builder uses this helper to derive deposit proofs, and noriMint() later recomputes the root on-chain and requires it to match the verified Ethereum deposit root. Whenever the number of leaves in the tree is not a power of 2 (i.e., there are dummy nodes in the tree), due to this incorrect calculation of the Merkle root, valid deposits would become unmintable even though the Ethereum proof and deposit data are correct.
+
+The fix is relatively straightforward: either reverse the order of the result of getMerkleZeros, or replace parentLevel[i] = zeros[level]; with parentLevel[i] = zeros[depth + 1 - level];.
+
+### Response
+
+The non-standard indexing is acknowledged. The same reversed indexing exists symmetrically in both the TypeScript (`merkleTree.ts`) and Rust (`merkle_poseidon_fixed.rs`) implementations across all three affected functions: `buildMerkleTree`/`build_merkle_tree`, `foldMerkleLeft`/`fold_merkle_left`, and `getMerklePathFromLeaves`/`get_merkle_path_from_leaves`. Because both producers in this closed system use the same non-standard convention, the computed roots agree across languages for all leaf counts. We do not believe there is a soundness or completeness failure in the deployed system. If the bug were asymmetric, failures would appear at any non-power-of-two count leaving adjacent dummies, the smallest being n=5, then 6, 9, 10, 11, 12, 13. Applying the proposed fix to only one side would introduce the completeness failure described in the report. The mistake cancels out leaving it safe as written but highly non-standard. Worth fixing but needs to be done carefully to avoid regression of the mint function.
+
+### Discussion
+
+After discussion it was noted that the two cited tests are not sufficient to rule out cross-language divergence when run in isolation, as each only checks self-consistency within its own language. This is agreed. The tests were not designed to be used in isolation. They were designed to be used in concert: the raw output from any two of the three test suites (Rust, TypeScript non-provable, TypeScript provable) was compared using an uncommitted comparison script that normalised and diffed leaves and roots line-by-line across languages. An improved version of this script (`o1js-zk-utils/test/cross-reference-roots.sh`) is now committed to nori-bridge-sdk for transparency.
+
+Three test suites cover this code:
+
+1. Rust - `cargo test -p nori-hash test_all_leaf_counts_and_indices_with_build_and_fold` (n_leaves 0-50)
+2. TypeScript (non-provable) - `npm run test -- -t "test_all_leaf_counts_and_indices_with_build_and_fold"` (n_leaves 0-50)
+3. TypeScript (provable) - `npm run test -- -t "test_all_leaf_counts_and_indices_with_pipeline"` (n_leaves 0-10, truncated for speed; previously run to 50)
+
+This cross-referencing is a sample-based confidence check, not a claim of completeness proof.
+
+The finding correctly identifies a deviation from the standard Merkle zero-hash convention. While harmless in the current closed two-implementation system, non-standard indexing would be a problem for any future third-party verifier or public auditability tooling that assumes the standard convention. The fix is accepted and will be applied to both sides simultaneously. Testing will be bolstered first (commit 1) to expose the non-standard indexing against independent reference implementations, then the fix applied (commit 2), so that the before and after results can be documented in this summary.
+
+### Commit 1 - Test exposure of the non-standard indexing
+
+- **Regression tests** (`o1js-zk-utils/src/merkle-attestor/merkleTree.spec.ts`): added `regression_a2090_bruteforce_reference_buildMerkleTree`, `regression_a2090_bruteforce_reference_foldMerkleLeft`, `regression_a2090_o1js_merkle_tree_reference_buildMerkleTree`, and `regression_a2090_o1js_merkle_tree_reference_foldMerkleLeft` as `test.each` over leaf counts [1, 3, 5, 6, 9, 17] verifying `buildMerkleTree` and `foldMerkleLeft` against two independent reference implementations. The brute-force reference pads with Field(0) and hashes every pair with no zeros cache. The o1js `MerkleTree` reference uses the standard o1js Merkle tree implementation. Neither references the zeros array. Leaf counts 5, 6, 9, 17 exercise the bug (adjacent dummy nodes at various depths); 1 and 3 are sanity cases where only a lone dummy pairs with a real leaf.
+- **Cross-reference script** (`o1js-zk-utils/test/cross-reference-roots.sh`): committed for reproducible cross-language verification of leaves and roots across the Rust, TypeScript non-provable, and TypeScript provable test suites. See `o1js-zk-utils/test/CROSS-REFERENCE-ROOTS.md` for usage.
+
+Results:
+
+- Regression tests: nLeaves 1 and 3 pass (no adjacent dummies, 8 pass). nLeaves 5, 6, 9, 17 fail against both the brute-force and o1js `MerkleTree` references for both `buildMerkleTree` and `foldMerkleLeft` (8 failures per reference, 16 fail, 24 total checks), confirming the non-standard indexing is detectable and diverges from the standard convention.
+- Self-consistency (Rust): passes 0-50 leaves.
+- Self-consistency (TypeScript non-provable): passes 0-50 leaves.
+- Self-consistency (TypeScript provable): passes 0-10 leaves.
+- Cross-reference (unpatched Rust vs unpatched TypeScript non-provable): 51 leaf counts, all leaves and roots match. Zero differences.
+- Cross-reference (unpatched Rust vs unpatched TypeScript provable): 11 leaf counts (0-10), all leaves and roots match. Zero differences.
+
 ## 28/4/26
 
 ### Migrated to @nori-zk/mina-attestations Fork

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,20 @@ Results:
 - Cross-reference (unpatched Rust vs unpatched TypeScript non-provable): 51 leaf counts, all leaves and roots match. Zero differences.
 - Cross-reference (unpatched Rust vs unpatched TypeScript provable): 11 leaf counts (0-10), all leaves and roots match. Zero differences.
 
+### Commit 2 - Fix applied
+
+- **`zeros[level]` corrected to `zeros[depth + 1 - level]`** (`o1js-zk-utils/src/merkle-attestor/merkleTree.ts`): three sites patched in `buildMerkleTree` (line 86), `foldMerkleLeft` (line 144), and `getMerklePathFromLeaves` (line 219). When the tree-building loop is at a given `level` counting down from `depth`, the parent node of two dummy children represents an all-zero subtree of height `depth + 1 - level`. The corrected index selects the matching precomputed zero hash from `getMerkleZeros`.
+
+Results:
+
+- Regression tests: 24 pass, 0 fail. All leaf counts [1, 3, 5, 6, 9, 17] now match both the brute-force and o1js `MerkleTree` references for both `buildMerkleTree` and `foldMerkleLeft`.
+- Self-consistency (Rust): passes 0-50 leaves.
+- Self-consistency (TypeScript non-provable): passes 0-50 leaves.
+- Self-consistency (TypeScript provable): passes 0-10 leaves.
+- Cross-reference (patched Rust vs patched TypeScript non-provable): 51 leaf counts, 0 leaf mismatches, 0 root mismatches.
+- Cross-reference (patched Rust vs patched TypeScript provable): 51 leaf counts checked, 0 root mismatches, 40 leaf mismatches (all MISSING, provable suite only runs 0-10, no data exists for 11-50), 11 overlapping leaf counts all leaves and roots match.
+- Cross-reference (patched TypeScript non-provable vs patched TypeScript provable): 51 leaf counts checked, 0 root mismatches, 40 leaf mismatches (all MISSING, provable suite only runs 0-10, no data exists for 11-50), 11 overlapping leaf counts all leaves and roots match.
+
 ## 28/4/26
 
 ### Migrated to @nori-zk/mina-attestations Fork

--- a/o1js-zk-utils/src/merkle-attestor/merkleTree.spec.ts
+++ b/o1js-zk-utils/src/merkle-attestor/merkleTree.spec.ts
@@ -1,4 +1,4 @@
-import { Field } from 'o1js';
+import { Field, MerkleTree, Poseidon } from 'o1js';
 import {
     computeMerkleTreeDepthAndSize,
     getMerkleZeros,
@@ -44,6 +44,120 @@ function fullMerkleTest(
 
     return recomputedRoot;
 }
+
+// Brute-force reference: pad with Field(0), hash every pair, no zeros cache.
+function referenceRoot(leaves: Field[], paddedSize: number): Field {
+    let level = [...leaves];
+    while (level.length < paddedSize) level.push(Field(0));
+    while (level.length > 1) {
+        const next: Field[] = [];
+        for (let i = 0; i < level.length; i += 2) {
+            next.push(Poseidon.hash([level[i], level[i + 1]]));
+        }
+        level = next;
+    }
+    return level[0];
+}
+
+describe('regression_a2090_zeros_indexing', () => {
+    // 1,3  -- no dummy pairs (sanity)
+    // 5,6  -- dummy pairs at depth 3
+    // 9    -- dummy pairs at depth 4
+    // 17   -- dummy pairs at depth 5
+    test.each([1, 3, 5, 6, 9, 17])(
+        'regression_a2090_bruteforce_reference_buildMerkleTree nLeaves=%i',
+        (nLeaves) => {
+            const pairs: Array<[Bytes32, Bytes32]> = [];
+            for (let i = 0; i < nLeaves; i++) {
+                pairs.push([dummyCodeChallenge(i), dummyValue(i)]);
+            }
+            const leaves = buildLeavesNonProvable(pairs);
+            const { depth, paddedSize } =
+                computeMerkleTreeDepthAndSize(nLeaves);
+            const zeros = getMerkleZeros(depth);
+
+            const expected = referenceRoot(leaves, paddedSize);
+
+            const tree = buildMerkleTree([...leaves], paddedSize, depth, zeros);
+            expect(tree[0][0].equals(expected).toBoolean()).toBe(true);
+        }
+    );
+
+    test.each([1, 3, 5, 6, 9, 17])(
+        'regression_a2090_bruteforce_reference_foldMerkleLeft nLeaves=%i',
+        (nLeaves) => {
+            const pairs: Array<[Bytes32, Bytes32]> = [];
+            for (let i = 0; i < nLeaves; i++) {
+                pairs.push([dummyCodeChallenge(i), dummyValue(i)]);
+            }
+            const leaves = buildLeavesNonProvable(pairs);
+            const { depth, paddedSize } =
+                computeMerkleTreeDepthAndSize(nLeaves);
+            const zeros = getMerkleZeros(depth);
+
+            const expected = referenceRoot(leaves, paddedSize);
+
+            const rootFold = foldMerkleLeft(
+                [...leaves],
+                paddedSize,
+                depth,
+                zeros
+            );
+            expect(rootFold.equals(expected).toBoolean()).toBe(true);
+        }
+    );
+
+    test.each([1, 3, 5, 6, 9, 17])(
+        'regression_a2090_o1js_merkle_tree_reference_buildMerkleTree nLeaves=%i',
+        (nLeaves) => {
+            const pairs: Array<[Bytes32, Bytes32]> = [];
+            for (let i = 0; i < nLeaves; i++) {
+                pairs.push([dummyCodeChallenge(i), dummyValue(i)]);
+            }
+            const leaves = buildLeavesNonProvable(pairs);
+            const { depth, paddedSize } =
+                computeMerkleTreeDepthAndSize(nLeaves);
+            const zeros = getMerkleZeros(depth);
+
+            const o1jsTree = new MerkleTree(depth + 1);
+            for (let i = 0; i < nLeaves; i++) {
+                o1jsTree.setLeaf(BigInt(i), leaves[i]);
+            }
+            const o1jsRoot = o1jsTree.getRoot();
+
+            const tree = buildMerkleTree([...leaves], paddedSize, depth, zeros);
+            expect(tree[0][0].equals(o1jsRoot).toBoolean()).toBe(true);
+        }
+    );
+
+    test.each([1, 3, 5, 6, 9, 17])(
+        'regression_a2090_o1js_merkle_tree_reference_foldMerkleLeft nLeaves=%i',
+        (nLeaves) => {
+            const pairs: Array<[Bytes32, Bytes32]> = [];
+            for (let i = 0; i < nLeaves; i++) {
+                pairs.push([dummyCodeChallenge(i), dummyValue(i)]);
+            }
+            const leaves = buildLeavesNonProvable(pairs);
+            const { depth, paddedSize } =
+                computeMerkleTreeDepthAndSize(nLeaves);
+            const zeros = getMerkleZeros(depth);
+
+            const o1jsTree = new MerkleTree(depth + 1);
+            for (let i = 0; i < nLeaves; i++) {
+                o1jsTree.setLeaf(BigInt(i), leaves[i]);
+            }
+            const o1jsRoot = o1jsTree.getRoot();
+
+            const rootFold = foldMerkleLeft(
+                [...leaves],
+                paddedSize,
+                depth,
+                zeros
+            );
+            expect(rootFold.equals(o1jsRoot).toBoolean()).toBe(true);
+        }
+    );
+});
 
 describe('Merkle Fixed Tests', () => {
     test('test_large_slots', () => {

--- a/o1js-zk-utils/src/merkle-attestor/merkleTree.ts
+++ b/o1js-zk-utils/src/merkle-attestor/merkleTree.ts
@@ -83,7 +83,7 @@ export function buildMerkleTree(
 
             if (leftIdx >= nNonDummyNodes) {
                 // Both left and right dummy nodes, use zeros cache
-                parentLevel[i] = zeros[level];
+                parentLevel[i] = zeros[depth + 1 - level];
             } else {
                 const rightIdx = leftIdx + 1;
                 // Atleast one of left and right are real.
@@ -141,7 +141,7 @@ export function foldMerkleLeft(
 
             if (leftIdx >= nNonDummyNodes) {
                 // Both left and right are dummy nodes — use cached zero for this level
-                leaves[i] = zeros[level];
+                leaves[i] = zeros[depth + 1 - level];
             } else {
                 // Atleast one of left and right are real.
                 const rightIdx = leftIdx + 1;
@@ -216,7 +216,7 @@ export function getMerklePathFromLeaves(
 
             if (leftIdx >= nNonDummyNodes) {
                 // Both left and right are dummy nodes; use zero hash for this level
-                merkleNodes[i] = zeros[level];
+                merkleNodes[i] = zeros[depth + 1 - level];
             } else {
                 const rightIdx = leftIdx + 1;
                 // Atleast one of left and right are real.

--- a/o1js-zk-utils/test/CROSS-REFERENCE-ROOTS.md
+++ b/o1js-zk-utils/test/CROSS-REFERENCE-ROOTS.md
@@ -1,0 +1,47 @@
+# Cross-Reference Roots
+
+Compares Merkle leaves and roots across any two of the three test suites to verify cross-language agreement.
+
+## Test suites
+
+1. **Rust** - `cargo test -p nori-hash test_all_leaf_counts_and_indices_with_build_and_fold -- --nocapture` (nLeaves 0-50)
+2. **TypeScript (non-provable)** - `npm run test -- -t "test_all_leaf_counts_and_indices_with_build_and_fold"` (nLeaves 0-50)
+3. **TypeScript (provable)** - `npm run test -- -t "test_all_leaf_counts_and_indices_with_pipeline"` (nLeaves 0-10, previously run to 50, dialed back for test runtime)
+
+## Usage
+
+### 1. Capture test output
+
+```bash
+# Rust (from nori-bridge-head)
+cargo test -p nori-hash test_all_leaf_counts_and_indices_with_build_and_fold -- --nocapture 2>&1 > /tmp/rust_output.txt
+
+# TypeScript non-provable (from nori-bridge-sdk/o1js-zk-utils)
+npm run test -- -t "test_all_leaf_counts_and_indices_with_build_and_fold" 2>&1 > /tmp/ts_output.txt
+
+# TypeScript provable (from nori-bridge-sdk/o1js-zk-utils)
+npm run test -- -t "test_all_leaf_counts_and_indices_with_pipeline" 2>&1 > /tmp/ts_provable_output.txt
+```
+
+### 2. Run the cross-reference script
+
+```bash
+bash cross-reference-roots.sh /tmp/rust_output.txt /tmp/ts_output.txt
+bash cross-reference-roots.sh /tmp/rust_output.txt /tmp/ts_provable_output.txt
+bash cross-reference-roots.sh /tmp/ts_output.txt /tmp/ts_provable_output.txt
+```
+
+## Output
+
+The script normalises the output formats (Rust uses `leaves=` and `root_via_fold =`, TypeScript uses `leaves ` and `rootViaFold =`) and compares line-by-line.
+
+- `MATCH` - leaves and root agree for that leaf count
+- `LEAF MISMATCH` - leaf hashes differ (indicates a hashing divergence)
+- `ROOT MISMATCH (leaves match)` - leaves agree but root differs (indicates a tree-building divergence, e.g. zeros indexing)
+- `MISSING` - one side has data and the other does not (expected when comparing suites with different ranges)
+- `WARNING: no leaf data from either side` - neither side produced leaf data for that count (e.g. nLeaves=0)
+- `WARNING: no root data from either side` - neither side produced root data for that count
+
+## Scope and limitations
+
+This is a sample-based confidence check. The Rust and TypeScript non-provable suites cover nLeaves 0-50. The TypeScript provable suite covers nLeaves 0-10 (previously run to 50, truncated for test runtime). It verifies that the implementations produce identical leaf hashes and identical Merkle roots for all tested leaf counts. It does not constitute a completeness proof.

--- a/o1js-zk-utils/test/cross-reference-roots.sh
+++ b/o1js-zk-utils/test/cross-reference-roots.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# Cross-reference two Merkle test output files (leaves + roots).
+# Accepts raw output from any of the three test suites:
+#   - Rust:        cargo test -p nori-hash test_all_leaf_counts_and_indices_with_build_and_fold -- --nocapture
+#   - TS:          npm run test -- -t "test_all_leaf_counts_and_indices_with_build_and_fold"
+#   - TS provable: npm run test -- -t "test_all_leaf_counts_and_indices_with_pipeline"
+#
+# Usage: bash cross-reference-roots.sh <output_a> <output_b>
+
+set -euo pipefail
+
+if [ $# -ne 2 ]; then
+    echo "Usage: $0 <output_a> <output_b>"
+    exit 1
+fi
+
+FILE_A="$1"
+FILE_B="$2"
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "$TMPDIR"' EXIT
+
+# Normalise leaves lines across Rust/TS formats into: comma-separated values, no spaces, no trailing comma
+extract_leaves() {
+    grep -E "^\s*leaves" "$1" \
+        | sed 's/.*leaves[= ]*//' \
+        | sed 's/\s*,\s*/,/g' \
+        | sed 's/,$//' \
+        | sed 's/^\s*//;s/\s*$//'
+}
+
+# Normalise root lines across Rust (root_via_fold) and TS (rootViaFold)
+extract_roots() {
+    grep -E "root_via_fold|rootViaFold" "$1" \
+        | sed 's/.*root_via_fold = //;s/.*rootViaFold = //' \
+        | sed 's/^\s*//;s/\s*$//'
+}
+
+extract_leaves "$FILE_A" > "$TMPDIR/a_leaves.txt"
+extract_leaves "$FILE_B" > "$TMPDIR/b_leaves.txt"
+extract_roots "$FILE_A" > "$TMPDIR/a_roots.txt"
+extract_roots "$FILE_B" > "$TMPDIR/b_roots.txt"
+
+LEAF_MISMATCHES=0
+ROOT_MISMATCHES=0
+LINE=0
+
+while IFS=$'\t' read -r leaf_a leaf_b; do
+    read -r root_a root_b <&3 || true
+    if [ -z "$leaf_a" ] && [ -z "$leaf_b" ]; then
+        printf "nLeaves=%3d  WARNING: no leaf data from either side\n" "$LINE"
+    elif [ -z "$leaf_a" ] || [ -z "$leaf_b" ]; then
+        printf "nLeaves=%3d  MISSING\n" "$LINE"
+        [ -z "$leaf_a" ] && printf "  A: (no data)\n" || printf "  A: %s\n" "$leaf_a"
+        [ -z "$leaf_b" ] && printf "  B: (no data)\n" || printf "  B: %s\n" "$leaf_b"
+        LEAF_MISMATCHES=$((LEAF_MISMATCHES + 1))
+    elif [ "$leaf_a" != "$leaf_b" ]; then
+        printf "nLeaves=%3d  LEAF MISMATCH\n" "$LINE"
+        printf "  A: %s\n" "$leaf_a"
+        printf "  B: %s\n" "$leaf_b"
+        LEAF_MISMATCHES=$((LEAF_MISMATCHES + 1))
+    elif [ -z "$root_a" ] && [ -z "$root_b" ]; then
+        printf "nLeaves=%3d  WARNING: no root data from either side\n" "$LINE"
+    elif [ -z "$root_a" ] || [ -z "$root_b" ]; then
+        printf "nLeaves=%3d  MISSING ROOT\n" "$LINE"
+        [ -z "$root_a" ] && printf "  A: (no data)\n" || printf "  A: %s\n" "$root_a"
+        [ -z "$root_b" ] && printf "  B: (no data)\n" || printf "  B: %s\n" "$root_b"
+        ROOT_MISMATCHES=$((ROOT_MISMATCHES + 1))
+    elif [ "$root_a" != "$root_b" ]; then
+        printf "nLeaves=%3d  ROOT MISMATCH (leaves match)\n" "$LINE"
+        printf "  A: %s\n" "$root_a"
+        printf "  B: %s\n" "$root_b"
+        ROOT_MISMATCHES=$((ROOT_MISMATCHES + 1))
+    else
+        printf "nLeaves=%3d  MATCH\n" "$LINE"
+    fi
+    LINE=$((LINE + 1))
+done < <(paste "$TMPDIR/a_leaves.txt" "$TMPDIR/b_leaves.txt") \
+     3< <(paste "$TMPDIR/a_roots.txt" "$TMPDIR/b_roots.txt")
+
+echo ""
+echo "Checked $LINE leaf counts."
+echo "Leaf mismatches: $LEAF_MISMATCHES"
+echo "Root mismatches: $ROOT_MISMATCHES"
+if [ "$LEAF_MISMATCHES" -eq 0 ] && [ "$ROOT_MISMATCHES" -eq 0 ]; then
+    echo "RESULT: All leaves and roots match."
+else
+    echo "RESULT: Mismatches found."
+fi


### PR DESCRIPTION
## Finding

A2090: `buildMerkleTree` uses the `zeros` array backwards.

In `buildMerkleTree`, `foldMerkleLeft`, and `getMerklePathFromLeaves`, the zeros cache is indexed by `level` when it should be indexed by `depth + 1 - level`. The same reversed indexing exists symmetrically in the Rust implementation (`merkle_poseidon_fixed.rs`) in nori-bridge-head. The fix will be applied to both sides simultaneously.

## Resolution

- 769c5ea - Commit 1: regression tests exposing non-standard zeros indexing (8 pass, 16 fail, 24 total checks)
- f827077 - Commit 2: `zeros[level]` corrected to `zeros[depth + 1 - level]` in 3 sites, all regression tests pass (24 pass, 0 fail)

See [CHANGELOG.md](https://github.com/Nori-zk/nori-bridge-sdk/blob/FIX/audit-a2090/CHANGELOG.md#15526---audit-a2090-non-standard-merkle-zero-indexing) for the full finding (verbatim), response, discussion, and detailed results.