### PR TITLE
FIX: stale adminSetDepositRoot signatures across test specs after 427…

### DIFF
--- a/contracts/mina/src/tests/41428.inflightMint.lightnet.integration.spec.ts
+++ b/contracts/mina/src/tests/41428.inflightMint.lightnet.integration.spec.ts
@@ -102,14 +102,16 @@ async function fetchWindowRoots(): Promise<Field[]> {
     return actionBatches.flat();
 }
 
-/** The real oldest action to evict: Field(0) until full, else the first window root. */
+/** The real oldest action to evict: Field(0) until full, else the first window root.
+ * NOTE (4279a fix): oldestAction is no longer caller-supplied; derived in-circuit. */
 async function honestOldest(): Promise<Field> {
     const windowRoots = await fetchWindowRoots();
     if (windowRoots.length < maxWindow) return Field(0);
     return windowRoots[0];
 }
 
-/** Dispatch a deposit root via adminSetDepositRoot, passing the real oldest action. */
+/** Dispatch a deposit root via adminSetDepositRoot, passing the real oldest action.
+ * NOTE (4279a fix): oldestAction is no longer caller-supplied; derived in-circuit. */
 async function adminDispatch(root: Field) {
     const oldest = await honestOldest();
     void root;
@@ -119,7 +121,8 @@ async function adminDispatch(root: Field) {
     // method to reproduce against lightnet.
     // await txSend({
     //     body: async () => {
-    //         await noriTokenBridge.adminSetDepositRoot(root, oldest);
+    //         // NOTE (4279a fix): oldest param removed; derived in-circuit.
+    //         await noriTokenBridge.adminSetDepositRoot(root);
     //     },
     //     sender: admin.publicKey,
     //     signers: [admin.privateKey],

--- a/contracts/mina/src/tests/NoriTokenBridge.full.lightnet.integration.spec.ts
+++ b/contracts/mina/src/tests/NoriTokenBridge.full.lightnet.integration.spec.ts
@@ -891,7 +891,6 @@ describe('NoriTokenBridge (Worker-driven, full)', () => {
             //     admin.privateKey.toBase58(),
             //     noriTokenBridgeKeypair.publicKey.toBase58(),
             //     aliceRoot.toBigInt().toString(),
-            //     '0',
             //     fee
             // );
             await fetchAccount({
@@ -966,7 +965,6 @@ describe('NoriTokenBridge (Worker-driven, full)', () => {
                 //     admin.privateKey.toBase58(),
                 //     noriTokenBridgeKeypair.publicKey.toBase58(),
                 //     aliceRoot2.toBigInt().toString(),
-                //     '0',
                 //     fee
                 // );
                 await fetchAccount({
@@ -1079,20 +1077,11 @@ describe('NoriTokenBridge (Worker-driven, full)', () => {
                                 merkleInput
                             );
 
-                        // Dispatch this root into the window via the tester worker.
-                        const windowIsFull = allDispatchedRoots.length >= 32;
-                        const oldest = windowIsFull
-                            ? allDispatchedRoots[
-                            allDispatchedRoots.length - 32
-                            ]
-                            : Field(0);
-                        void oldest;
                         // adminSetDepositRoot disabled in production — see top-of-suite note.
                         // await tester.adminSetDepositRoot(
                         //     admin.privateKey.toBase58(),
                         //     noriTokenBridgeKeypair.publicKey.toBase58(),
                         //     root.toBigInt().toString(),
-                        //     oldest.toBigInt().toString(),
                         //     fee
                         // );
                         allDispatchedRoots.push(root);
@@ -1145,19 +1134,11 @@ describe('NoriTokenBridge (Worker-driven, full)', () => {
                 } else {
                     test(`window rotation root #${i}: dispatch deposit root (worker)`, async () => {
                         const dummyRoot = Field(1_000_000n + BigInt(i));
-                        const windowIsFull = allDispatchedRoots.length >= 32;
-                        const oldest = windowIsFull
-                            ? allDispatchedRoots[
-                            allDispatchedRoots.length - 32
-                            ]
-                            : Field(0);
-                        void oldest;
                         // adminSetDepositRoot disabled in production — see top-of-suite note.
                         // await tester.adminSetDepositRoot(
                         //     admin.privateKey.toBase58(),
                         //     noriTokenBridgeKeypair.publicKey.toBase58(),
                         //     dummyRoot.toBigInt().toString(),
-                        //     oldest.toBigInt().toString(),
                         //     fee
                         // );
                         allDispatchedRoots.push(dummyRoot);

--- a/contracts/mina/src/tests/NoriTokenBridge.happyPath.lightnet.integration.spec.ts
+++ b/contracts/mina/src/tests/NoriTokenBridge.happyPath.lightnet.integration.spec.ts
@@ -465,7 +465,6 @@ describe('NoriTokenBridge (Worker-driven)', () => {
             //     admin.privateKey.toBase58(),
             //     noriTokenBridgeKeypair.publicKey.toBase58(),
             //     depositRoot.toBigInt().toString(),
-            //     '0',
             //     fee
             // );
 

--- a/contracts/mina/src/tests/main-thread/NoriTokenBridge.full.lightnet.integration.spec.ts
+++ b/contracts/mina/src/tests/main-thread/NoriTokenBridge.full.lightnet.integration.spec.ts
@@ -959,16 +959,10 @@ describe('NoriTokenBridge', () => {
                         );
                         const root = getContractDepositSlotRootFromContractDepositAndWitness(merkleInput);
 
-                        // Dispatch this root into the window
-                        const windowIsFull = allDispatchedRoots.length >= 32;
-                        const oldest = windowIsFull
-                            ? allDispatchedRoots[allDispatchedRoots.length - 32]
-                            : Field(0);
-                        void oldest;
                         // adminSetDepositRoot disabled in production — see top-of-suite note.
                         // await txSend({
                         //     body: async () => {
-                        //         await noriTokenBridge.adminSetDepositRoot(root, oldest);
+                        //         await noriTokenBridge.adminSetDepositRoot(root);
                         //     },
                         //     sender: admin.publicKey,
                         //     signers: [admin.privateKey],
@@ -1006,15 +1000,10 @@ describe('NoriTokenBridge', () => {
                 } else {
                     test(`window rotation root #${i}: dispatch deposit root`, async () => {
                         const dummyRoot = Field(1_000_000n + BigInt(i));
-                        const windowIsFull = allDispatchedRoots.length >= 32;
-                        const oldest = windowIsFull
-                            ? allDispatchedRoots[allDispatchedRoots.length - 32]
-                            : Field(0);
-                        void oldest;
                         // adminSetDepositRoot disabled in production — see top-of-suite note.
                         // await txSend({
                         //     body: async () => {
-                        //         await noriTokenBridge.adminSetDepositRoot(dummyRoot, oldest);
+                        //         await noriTokenBridge.adminSetDepositRoot(dummyRoot);
                         //     },
                         //     sender: admin.publicKey,
                         //     signers: [admin.privateKey],

--- a/contracts/mina/src/tests/unit/4279a.evictionWitness.reggression.spec.ts
+++ b/contracts/mina/src/tests/unit/4279a.evictionWitness.reggression.spec.ts
@@ -17,6 +17,12 @@
  * still mintable. It FAILS on the unfixed contract (windowStart is poisoned)
  * and passes once eviction derives the oldest action in-circuit.
  *
+ * NOTE (4279a fix): the attack surface described above no longer exists.
+ * dispatchAndEvict() now derives the oldest action in-circuit via
+ * reducer.reduce(); there is no caller-supplied oldestAction parameter
+ * to exploit. This test remains as a regression guard: it confirms the
+ * window stays healthy after eviction without any caller input.
+ *
  * Self-contained: own LocalBlockchain (proofsEnabled: false), deploy and a
  * single test. Requires the test-only `adminSetDepositRoot` method to be
  * enabled on the contract.
@@ -83,7 +89,8 @@ async function fetchWindowRoots(bridge: NoriTokenBridge): Promise<Field[]> {
     return actionBatches.flat();
 }
 
-/** Dispatch a deposit root via adminSetDepositRoot with an explicit oldestAction. */
+/** Dispatch a deposit root via adminSetDepositRoot with an explicit oldestAction.
+ * NOTE (4279a fix): oldestAction is no longer caller-supplied; derived in-circuit. */
 async function adminDispatch(root: Field) {
     void root
     // await txSend({


### PR DESCRIPTION
…9a merge. Removed caller-supplied oldest/zero args from commented-out call sites to match the post-4279a single-arg contract API, added amendment notes to the 41428 and 4279a audit regression specs explaining oldestAction is now derived in-circuit.