### PR TITLE
Fix/audit 7f3a1: codeChallenge is unnecessarily bound to msg.sender in lockTokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## 23/6/26 - Finding 7f3a1: codeChallenge is unnecessarily bound to msg.sender in lockTokens
+
+### Finding (verbatim)
+
+Hey team, I want to double-check the reasoning for binding codeChallenge to msg.sender on the Ethereum side in lockTokens.
+Could you clarify why this is required? Have you considered not binding codeChallenge to a single depositor and allowing anyone to deposit to that codeChallenge?
+Potential advantages of not binding are better liveness and UX (it eliminates mempool front-run grief revert), but there may be stronger reasons to keep the single-owner deposit-key invariant.
+
+### Discussion
+
+The design went through two iterations. In the earlier iteration codeChallenge was derived from an Ethereum signature and a Mina public key. After the latest redesign the Mina signature was adopted, which produces a deterministic signature for a given message. The msg.sender binding was left in the contract as a result of cognitive bias carried over from the prior design. After careful review it was agreed internally that the binding is no longer required.
+
+The auditors confirmed that it can be removed without any impact.
+
+The original constraint existed because codeChallenge previously incorporated both keys, which required an additional constraint to ensure correct accounting for cumulative lockedTokens.
+
+### Response
+
+We agree and will relax the constraint.
+
+### Commit 1 - Regression test exposing the undesirable depositor binding
+
+`contracts/ethereum/test/NoriTokenBridge.ts` contained a test `Should bind Mina account to first depositor and reject others` asserting that a second depositor calling lockTokens with a codeChallenge already used by a different address is rejected with MinaAccountLinkedToDifferentDepositor. Prior to any code change this test passed, confirming the constraint was live. Because we are relaxing that constraint, this passing test here is itself an erroneous behaviour.
+
+`npm test -- --grep "Should bind Mina account to first depositor and reject others"` run in `contracts/ethereum` against the unmodified contract:
+
+Results:
+
+- 1 passing. The test passes against the unmodified contract, confirming the binding is live and that this behaviour is erroneous under the relaxed constraint.
+- We also noticed a typo in `Should set NORI_BRIDE_ZKAPP_ACCT_TOKEN_ID from constructor` and corrected that.
+
+We renamed and refactored the test `Should bind Mina account to first depositor and reject others` to assert the opposite `Should allow different depositors to lock to the same codeChallenge and accumulate correctly`. Updating the assertion from a failure should occur and the contract should revert - to the contract should permit the action of multiple ETH depositors sharing the same `codeChallenge`.
+
+The full test suite was run to ensure no other regressions:
+
+`npm run test`
+
+Result:
+
+`Should allow different depositors to lock to the same codeChallenge and accumulate correctly` fails with `SolidityError: VM Exception while processing transaction: reverted with an unrecognized custom error (return data: 0x30506bb1)` demonstrating the contracts undesirable rejection of the action - prior to relaxing the constraint.
+
 ## 02/6/26 - Finding 41428: In-flight mints are invalidated by the next `update()`
 
 ### Finding (verbatim)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,23 @@ Result:
 
 `Should allow different depositors to lock to the same codeChallenge and accumulate correctly` fails with `SolidityError: VM Exception while processing transaction: reverted with an unrecognized custom error (return data: 0x30506bb1)` demonstrating the contracts undesirable rejection of the action - prior to relaxing the constraint.
 
+### Commit 2 - Fix applied
+
+- `contracts/ethereum/contracts/NoriTokenBridge.sol`
+    - Removed `depositKeyToEthAddress` mapping from  which captures the binding from a `codeChallenge` to an ETH address
+    - Removed `MinaAccountLinkedToDifferentDepositor` bespoke error.
+    - Removed `Enforce one ETH depositor per Mina account` validation logic.
+- `contracts/mina/src/scram.ts`
+    - Updated documentation to remove references of `depositKeyToEthAddress`
+
+Re-ran the ethereum contract tests:
+
+`cd contracts/ethereum/contracts && npm run test`
+
+Result:
+
+62 tests passed, showing that the relaxed constraints allow the modified test to pass.
+
 ## 02/6/26 - Finding 41428: In-flight mints are invalidated by the next `update()`
 
 ### Finding (verbatim)

--- a/contracts/ethereum/contracts/NoriTokenBridge.sol
+++ b/contracts/ethereum/contracts/NoriTokenBridge.sol
@@ -36,7 +36,6 @@ contract NoriTokenBridge is ReentrancyGuard {
     error BelowMinLockAmount();
     error InvalidBridgeUnitMultiple();
     error TotalLockedOverflow();
-    error MinaAccountLinkedToDifferentDepositor();
     error InvalidLedger();
     error InvalidZkappAccount();
     error InvalidUnlockAmount();
@@ -61,8 +60,6 @@ contract NoriTokenBridge is ReentrancyGuard {
     // Total locked supply in bridge units
     uint256 public totalLockedBU;
 
-    // Mina account (depositKey) -> ETH depositor
-    mapping(uint256 => address) public depositKeyToEthAddress;
 
     /// @notice Mina bridge contract that validates and stores Mina states.
     MinaStateSettlement public stateSettlement;
@@ -222,33 +219,6 @@ contract NoriTokenBridge is ReentrancyGuard {
 
         // Ensure total locked supply does not exceed MAX_MAGNITUDE
         if (totalLockedBU + netBU > MAX_MAGNITUDE) revert TotalLockedOverflow();
-
-        // Enforce one ETH depositor per Mina account.
-        //
-        // Known limitation (mempool griefing): codeChallenge values are
-        // visible in the mempool before they confirm. An observer can copy
-        // a pending codeChallenge and submit their own lockTokens first,
-        // binding their address to that codeChallenge. The honest user's
-        // tx then reverts here with MinaAccountLinkedToDifferentDepositor,
-        // and they must pick a fresh codeChallenge to retry.
-        //
-        // Funds at risk: none. The attacker locks their own ETH but cannot
-        // mint on Mina — minting requires the SCRAM signature whose hash
-        // is the codeChallenge, which only the honest user holds. The
-        // honest user's tx reverted, so no ETH was sent. The attacker's
-        // ETH remains stuck against an unmintable codeChallenge.
-        //
-        // Mitigation is off-chain: the client UX is expected to generate a
-        // fresh codeChallenge per attempt and to retry with a new one when
-        // this revert is observed.
-        address linkedEthAddress = depositKeyToEthAddress[codeChallenge];
-        if (linkedEthAddress == address(0)) {
-            // First deposit: bind Mina account deposit key to sender
-            depositKeyToEthAddress[codeChallenge] = msg.sender;
-        } else {
-            if (linkedEthAddress != msg.sender)
-                revert MinaAccountLinkedToDifferentDepositor();
-        }
 
         // ===============================
         // LOCK LOGIC (bridge units internally)

--- a/contracts/ethereum/test/NoriTokenBridge.ts
+++ b/contracts/ethereum/test/NoriTokenBridge.ts
@@ -117,9 +117,9 @@ describe('NoriTokenBridge', () => {
             expect(await tokenBridge.feeRecipient()).to.equal(ethers.ZeroAddress);
         });
 
-        it('Should set NORI_BRIDE_ZKAPP_ACCT_TOKEN_ID from constructor', async function () {
+        it('Should set NORI_BRIDGE_ZKAPP_ACCT_TOKEN_ID from constructor', async function () {
             const { tokenBridge } = await deployTokenBridgeFixture();
-            expect(await tokenBridge.NORI_BRIDE_ZKAPP_ACCT_TOKEN_ID()).to.equal(ZKAPP_ACCT_TOKEN_ID);
+            expect(await tokenBridge.NORI_BRIDGE_ZKAPP_ACCT_TOKEN_ID()).to.equal(ZKAPP_ACCT_TOKEN_ID);
         });
 
         it('Should set NORI_STORAGE_ZKAPP_ACCT_VERIFICATION_KEY_HASH from constructor', async function () {
@@ -615,23 +615,21 @@ describe('NoriTokenBridge', () => {
             ).to.be.revertedWithCustomError(tokenBridge, 'InvalidBridgeUnitMultiple');
         });
 
-        it('Should bind Mina account to first depositor and reject others', async function () {
+        it('Should allow different depositors to lock to the same codeChallenge and accumulate correctly', async function () {
             const { tokenBridge, user1, user2 } = await deployTokenBridgeFixture();
-            const sendValue = ethers.parseEther('1.0');
+            const sendValue1 = ethers.parseEther('0.5');
+            const sendValue2 = ethers.parseEther('1.0');
+            const expectedBU = (sendValue1 + sendValue2) / WEI_PER_BRIDGE_UNIT;
 
             await tokenBridge
                 .connect(user1)
-                .lockTokens(codeChallengeBigInt, { value: sendValue });
-            const linked = await tokenBridge.depositKeyToEthAddress(
-                codeChallengeBigInt
-            );
-            expect(linked).to.equal(user1.address);
+                .lockTokens(codeChallengeBigInt, { value: sendValue1 });
+            await tokenBridge
+                .connect(user2)
+                .lockTokens(codeChallengeBigInt, { value: sendValue2 });
 
-            await expect(
-                tokenBridge
-                    .connect(user2)
-                    .lockTokens(codeChallengeBigInt, { value: sendValue })
-            ).to.be.revertedWithCustomError(tokenBridge, 'MinaAccountLinkedToDifferentDepositor');
+            const totalLocked = await tokenBridge.lockedTokens(codeChallengeBigInt);
+            expect(totalLocked).to.equal(expectedBU);
         });
 
         it('Should allow the same depositor to add more ETH to same Mina account', async function () {

--- a/contracts/mina/src/scram.ts
+++ b/contracts/mina/src/scram.ts
@@ -4,8 +4,8 @@
  * Short:
  *   SCRAM is a scheme where a Mina signature is Poseidon-hashed into a
  *   commitment (codeChallenge). The codeChallenge is stored on-chain within
- *   the Eth deposit smart contract as the key in the `lockedTokens` and
- *   `depositKeyToEthAddress` maps. Later, the claimant supplies the original
+ *   the Eth deposit smart contract as the key in the `lockedTokens` map.
+ *   Later, the claimant supplies the original
  *   signature, publicKey, and message as private witnesses inside a ZK proof
  *   on the Mina side. The ZK circuit verifies both that the signature is
  *   valid for the claimed (publicKey, message) pair AND that its Poseidon
@@ -24,8 +24,7 @@
  *   1. Sign a message with the signer's Mina private key.
  *   2. Compute codeChallenge = Poseidon(signature.toFields()).
  *   3. Submit the codeChallenge to the Eth smart contract's lockTokens
- *      function, where it becomes the deposit key in `lockedTokens` and
- *      is bound to the depositor's ETH address in `depositKeyToEthAddress`.
+ *      function, where it becomes the deposit key in `lockedTokens`.
  *
  * On-chain Mina (ZK verification):
  *   1. Claimant supplies the original signature, publicKey, and message


### PR DESCRIPTION
Multiple eth depositors should be able to use the same codeChallenge. Fix in two parts:

- CHORE: audit 7f3a1 commit 1. Refactored Should bind Mina account to first depositor and reject others test to prove the opposite behaviour should be permitted Should allow different depositors to lock to the same codeChallenge and accumulate correctly https://github.com/Nori-zk/nori-bridge-sdk/commit/a5c75a3a6d22a46d9dd3cba58b8a3085b7ff7c8e
- FIX: audit 7f3a1 commit 2, removed depositKeyToEthAddress mapping, MinaAccountLinkedToDifferentDepositor error and distinct eth depositor per codeChallenge validation logic from 'contracts/ethereum/contracts/NoriTokenBridge.sol' https://github.com/Nori-zk/nori-bridge-sdk/commit/337c11a6d846ceaa0b26c13c594d64481dbe420d